### PR TITLE
usre story #3130040: Add support for bearer token

### DIFF
--- a/test-result-collection-tool/src/main/assemblies/readme.txt
+++ b/test-result-collection-tool/src/main/assemblies/readme.txt
@@ -21,6 +21,10 @@ Usage
                                        area
      --access-token                    External token to exchange with
                                        ALM Octane for authentication.
+     --bearer-token <TOKEN>            Bearer token for direct
+                                       authentication (no login required).
+                                       When provided, --user and --password
+                                       are not needed.
   -b,--backlog-item <ID>               assign the test result to backlog
                                        item
      --build-context-build-id <arg>    Build id for defining build context.
@@ -84,10 +88,12 @@ Example configuration file:
     sharedspace=1001
     # Server workspace ID
     workspace=1002
-    # Server username
+    # Server username (not required when using bearer-token)
     user=test@hpe.com
-    # Server username password
+    # Server username password (not required when using bearer-token)
     password=W3lcome1
+    # Bearer token for direct authentication (alternative to user + password)
+    # bearer-token=eyJhbGci...
     # Proxy host address
     proxyhost=proxy.ot.com
     # Proxy port number
@@ -127,6 +133,20 @@ The password can be entered in the following ways:
 *  Password is entered directly to command line (--password option)
 *  Password is entered from file (--password-file option)
 *  Password is part of configuration file (password option)
+
+Bearer Token authentication
+---------------------------
+For direct authentication using a bearer token, use the --bearer-token option.
+The token is sent as an Authorization: Bearer <token> header on every request.
+No username or password is required when using this option.
+
+When using bearer token authentication:
+* Provide the bearer token using --bearer-token option (or set bearer-token in the configuration file)
+* --user and --password are optional and ignored
+
+The bearer token can be provided in the following ways:
+*  Directly on the command line: --bearer-token <TOKEN>
+*  In the configuration file:   bearer-token=<TOKEN>
 
 Access Token authentication
 ---------------------------
@@ -205,3 +225,21 @@ file, which is placed in the same directory as this tool. Result file appears in
 
     java -jar test-result-collection-tool.jar --build-context-server-id 5b9c0376-169a-4e43-a279-8d7ef2810df6
     --build-context-job-id myJobId --build-context-build-id 1 JUnitOne.xml JUnitTwo.xml
+
+5.  Authenticate using a bearer token instead of username and password.
+
+    java -jar test-result-collection-tool.jar -s "http://localhost:8080"
+        -d 1001 -w 1002 --bearer-token "eyJhbGci..." JUnit.xml
+
+6.  Run from a Harness CI pipeline using a bearer token and build context.
+    The --build-context-job-id follows the format:
+      stage|~~|<orgIdentifier>|~~|<projectIdentifier>|~~|<pipelineIdentifier>|~~|<stageIdentifier>
+
+    java -jar test-result-collection-tool.jar \
+        -s "https://octane.example.com" -d 1001 -w 1002 \
+        --bearer-token "$OCTANE_BEARER_TOKEN" \
+        --build-context-server-id "339a2ec4-28bd-4e85-bdcd-ae8862ee20e1" \
+        --build-context-job-id "stage|~~|myOrg|~~|myProject|~~|myPipeline|~~|myStage" \
+        --build-context-build-id "$PIPELINE_EXECUTION_ID" \
+        target/surefire-reports/TEST-*.xml
+

--- a/test-result-collection-tool/src/main/assemblies/readme.txt
+++ b/test-result-collection-tool/src/main/assemblies/readme.txt
@@ -230,16 +230,3 @@ file, which is placed in the same directory as this tool. Result file appears in
 
     java -jar test-result-collection-tool.jar -s "http://localhost:8080"
         -d 1001 -w 1002 --bearer-token "eyJhbGci..." JUnit.xml
-
-6.  Run from a Harness CI pipeline using a bearer token and build context.
-    The --build-context-job-id follows the format:
-      stage|~~|<orgIdentifier>|~~|<projectIdentifier>|~~|<pipelineIdentifier>|~~|<stageIdentifier>
-
-    java -jar test-result-collection-tool.jar \
-        -s "https://octane.example.com" -d 1001 -w 1002 \
-        --bearer-token "$OCTANE_BEARER_TOKEN" \
-        --build-context-server-id "339a2ec4-28bd-4e85-bdcd-ae8862ee20e1" \
-        --build-context-job-id "stage|~~|myOrg|~~|myProject|~~|myPipeline|~~|myStage" \
-        --build-context-build-id "$PIPELINE_EXECUTION_ID" \
-        target/surefire-reports/TEST-*.xml
-

--- a/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/CliParser.java
+++ b/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/CliParser.java
@@ -89,6 +89,7 @@ public class CliParser {
 
         options.addOption(Option.builder("t").longOpt("tag").desc("assign environment tag to test runs").hasArg().argName("TYPE:VALUE").build());
         options.addOption(Option.builder().longOpt("access-token").desc("IDP access token for authentication").hasArg().argName("PASSWORD").build());
+        options.addOption(Option.builder().longOpt("bearer-token").desc("Bearer token for direct authentication (no login required)").hasArg().argName("TOKEN").build());
         options.addOption(Option.builder("f").longOpt("field").desc("assign field tag to test result, relevant for the following fields : Testing_Tool_Type, Framework, Test_Level, Testing_Tool_Type").hasArg().argName("TYPE:VALUE").build());
 
         options.addOption(Option.builder("r").longOpt("release").desc("assign release to test result").hasArg().argName("ID").type(Number.class).build());
@@ -110,7 +111,7 @@ public class CliParser {
 
         argsWithSingleOccurrence.addAll(Arrays.asList("o", "c", "s", "d", "w", "u", "p", "password-file", "r", "release-default", "m", "started", "check-status", "program",
                 "check-status-timeout", "proxy-host", "proxy-port", "proxy-user", "proxy-password", "proxy-password-file", "suite", "suite-external-run-id",
-                "build-context-server-id","build-context-build-id","build-context-job-id"));
+                "build-context-server-id","build-context-build-id","build-context-job-id", "bearer-token"));
         argsRestrictedForInternal.addAll(Arrays.asList("o", "t", "f", "r", "m", "a", "b", "started", "suite", "suite-external-run-id", "program", "release-default",
                 "build-context-server-id","build-context-build-id","build-context-job-id"));
         argsForBuildContext.addAll(Arrays.asList("build-context-server-id","build-context-build-id","build-context-job-id"));
@@ -199,7 +200,7 @@ public class CliParser {
                         System.out.println("Can not read the password file: " + cmd.getOptionValue("password-file"));
                         System.exit(ReturnCode.FAILURE.getReturnCode());
                     }
-                } else if (settings.getPassword() == null) {//password was not  added in configuration file
+                } else if (settings.getPassword() == null && !cmd.hasOption("bearer-token") && !settings.getBearerToken().isPresent()) {//password was not  added in configuration file
                     System.out.println("Please enter your password if it's required and hit enter: ");
                     settings.setPassword(new String(System.console().readPassword()).getBytes(StandardCharsets.UTF_8));
                 }
@@ -297,12 +298,16 @@ public class CliParser {
                 settings.setBuildContextJobId(cmd.getOptionValue("build-context-job-id"));
             }
 
-            if (!areSettingsValid(settings)) {
-                System.exit(ReturnCode.FAILURE.getReturnCode());
-            }
-
             if(cmd.hasOption(Settings.PROP_ACCESS_TOKEN)){
                 settings.setAccessToken(cmd.getOptionValue(Settings.PROP_ACCESS_TOKEN).getBytes(StandardCharsets.UTF_8));
+            }
+
+            if (cmd.hasOption(Settings.PROP_BEARER_TOKEN)) {
+                settings.setBearerToken(cmd.getOptionValue(Settings.PROP_BEARER_TOKEN).getBytes(StandardCharsets.UTF_8));
+            }
+
+            if (!areSettingsValid(settings)) {
+                System.exit(ReturnCode.FAILURE.getReturnCode());
             }
 
         } catch (ParseException e) {
@@ -463,6 +468,11 @@ public class CliParser {
                 return false;
             }
 
+            if (!isAuthenticationConfigured(settings)) {
+                System.out.println("Authentication not configured. Provide one of: (1) user + password, (2) user + password + access-token, or (3) bearer-token");
+                return false;
+            }
+
             if (settings.getProxyHost() != null && settings.getProxyPort() == null) {
                 System.out.println("Proxy port was not specified for proxy host: " + settings.getProxyHost());
                 return false;
@@ -483,6 +493,27 @@ public class CliParser {
                 return false;
             }
         }
+        return true;
+    }
+
+    private boolean isAuthenticationConfigured(Settings settings) {
+        // Bearer token is sufficient on its own
+        if (settings.getBearerToken().isPresent()) {
+            return true;
+        }
+
+        // Otherwise, user credentials are required
+        if (settings.getUser() == null || settings.getUser().isEmpty()) {
+            System.out.println("Mandatory setting 'user' was not specified in the CLI arguments or configuration file");
+            return false;
+        }
+
+        // Password is required for credential-based auth
+        if (settings.getPassword() == null || settings.getPassword().length == 0) {
+            System.out.println("Mandatory setting 'password' was not specified in the CLI arguments or configuration file");
+            return false;
+        }
+
         return true;
     }
 

--- a/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/RestClient.java
+++ b/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/RestClient.java
@@ -34,6 +34,7 @@ package com.microfocus.mqm.clt;
 
 import com.microfocus.mqm.clt.Exception.ValidationException;
 import com.microfocus.mqm.clt.authentication.AuthenticationMethod;
+import com.microfocus.mqm.clt.authentication.BearerTokenAuthenticationMethodImpl;
 import com.microfocus.mqm.clt.authentication.JSONAuthenticationMethodImpl;
 import com.microfocus.mqm.clt.authentication.TokenExchangeAuthenticationMethodImpl;
 import com.microfocus.mqm.clt.tests.TestResultPushStatus;
@@ -125,7 +126,10 @@ public class RestClient {
                 .setSocketTimeout(DEFAULT_SO_TIMEOUT)
                 .setConnectTimeout(DEFAULT_CONNECTION_TIMEOUT);
 
-        if(settings.getAccessToken().isEmpty() || settings.getAccessToken().get().length ==0 ){
+        if (settings.getBearerToken().isPresent()) {
+            this.authenticationMethod = new BearerTokenAuthenticationMethodImpl();
+            this.isLoggedIn = true;
+        } else if (settings.getAccessToken().isEmpty() || settings.getAccessToken().get().length == 0) {
             this.authenticationMethod = new JSONAuthenticationMethodImpl(cookieStore);
         } else {
             this.authenticationMethod = new TokenExchangeAuthenticationMethodImpl();
@@ -293,6 +297,17 @@ public class RestClient {
     }
 
     protected CloseableHttpResponse execute(HttpUriRequest request) throws IOException {
+        if (authenticationMethod.isPreAuthenticated()) {
+            authenticationMethod.addAuthorizationHeader(request, settings);
+            addClientTypeHeader(request);
+            CloseableHttpResponse response = httpClient.execute(request);
+            if (isLoginNecessary(response)) {
+                throw new RuntimeException(
+                        "Bearer token authentication failed. The token may be invalid or expired.");
+            }
+            return response;
+        }
+
         if (!isLoggedIn) {
             login();
         }
@@ -339,6 +354,9 @@ public class RestClient {
     }
 
     protected synchronized void logout() throws IOException {
+        if (authenticationMethod.isPreAuthenticated()) {
+            return;
+        }
         if (isLoggedIn) {
             HttpPost post = new HttpPost(createBaseUri(URI_LOGOUT));
             addClientTypeHeader(post);

--- a/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/Settings.java
+++ b/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/Settings.java
@@ -56,6 +56,7 @@ public class Settings {
     private static final String PROP_PROXY_PORT = "proxyport";
     private static final String PROP_PROXY_USER = "proxyuser";
     public static final String PROP_ACCESS_TOKEN = "access-token";
+    public static final String PROP_BEARER_TOKEN = "bearer-token";
 
     private String server;
     private Integer sharedspace;
@@ -96,6 +97,7 @@ public class Settings {
     private List<String> inputXmlFileNames;
 
     private byte[] accessToken;
+    private byte[] bearerToken;
 
     private DefaultConfigFilenameProvider defaultConfigFilenameProvider = new ImplDefaultConfigFilenameProvider();
 
@@ -116,6 +118,26 @@ public class Settings {
                 this.accessToken[i] = '\0';
             }
             this.accessToken = null;
+        }
+    }
+
+    public Optional<byte[]> getBearerToken() {
+        return (bearerToken == null || bearerToken.length == 0) ? Optional.empty() : Optional.of(bearerToken);
+    }
+
+    public void setBearerToken(byte[] bearerToken) {
+        if (this.bearerToken != null) {
+            clearBearerToken();
+        }
+        this.bearerToken = bearerToken;
+    }
+
+    private void clearBearerToken() {
+        if (this.bearerToken != null) {
+            for (int i = 0; i < this.bearerToken.length; i++) {
+                this.bearerToken[i] = '\0';
+            }
+            this.bearerToken = null;
         }
     }
 
@@ -146,6 +168,8 @@ public class Settings {
 
         byte[] accessToken = properties.getProperty(PROP_ACCESS_TOKEN) != null ? properties.getProperty(PROP_ACCESS_TOKEN).getBytes(StandardCharsets.UTF_8) : null;
         setAccessToken(accessToken);
+        byte[] bearerToken = properties.getProperty(PROP_BEARER_TOKEN) != null ? properties.getProperty(PROP_BEARER_TOKEN).getBytes(StandardCharsets.UTF_8) : null;
+        setBearerToken(bearerToken);
     }
 
     public String getServer() {
@@ -435,5 +459,6 @@ public class Settings {
             Arrays.fill(password, (byte) 0);  // overwrite in place
         }
         clearAccessToken();
+        clearBearerToken();
     }
 }

--- a/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/authentication/AuthenticationMethod.java
+++ b/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/authentication/AuthenticationMethod.java
@@ -4,10 +4,19 @@ import com.microfocus.mqm.clt.Settings;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.cookie.Cookie;
 
 public interface AuthenticationMethod {
     HttpPost getLoginRequest(Settings settings);
 
     Cookie handleCookies(HttpRequest request, HttpResponse response);
+
+    default boolean isPreAuthenticated() {
+        return false;
+    }
+
+    default void addAuthorizationHeader(HttpUriRequest request, Settings settings) {
+        // No-op by default - cookie-based authentication methods don't need this
+    }
 }

--- a/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/authentication/BearerTokenAuthenticationMethodImpl.java
+++ b/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/authentication/BearerTokenAuthenticationMethodImpl.java
@@ -1,0 +1,62 @@
+/*
+ *     Copyright 2015-2023 Open Text
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.microfocus.mqm.clt.authentication;
+
+import com.microfocus.mqm.clt.Settings;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.cookie.Cookie;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Bearer Token authentication method.
+ *
+ * This authentication method uses a pre-obtained bearer token that is added
+ * directly to the Authorization header of each request. No login/authentication
+ * flow is required.
+ */
+public class BearerTokenAuthenticationMethodImpl implements AuthenticationMethod {
+
+    @Override
+    public HttpPost getLoginRequest(Settings settings) {
+        throw new UnsupportedOperationException(
+                "Bearer token authentication does not require a login request");
+    }
+
+    @Override
+    public Cookie handleCookies(HttpRequest request, HttpResponse response) {
+        return null;
+    }
+
+    @Override
+    public boolean isPreAuthenticated() {
+        return true;
+    }
+
+    @Override
+    public void addAuthorizationHeader(HttpUriRequest request, Settings settings) {
+        byte[] token = settings.getBearerToken().orElseThrow(
+                () -> new IllegalStateException("Bearer token is not set"));
+        String tokenString = new String(token, StandardCharsets.UTF_8);
+        request.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + tokenString);
+    }
+}
+

--- a/test-result-collection-tool/src/test/java/com/microfocus/mqm/clt/CliParserTest.java
+++ b/test-result-collection-tool/src/test/java/com/microfocus/mqm/clt/CliParserTest.java
@@ -255,6 +255,18 @@ public class CliParserTest {
 
         settings.setWorkspace(1002);
         result = (Boolean) settingsValidation.invoke(cliParser, settings);
+        Assert.assertFalse(result); // no auth configured
+
+        // bearer token alone is sufficient
+        settings.setBearerToken("mytoken".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        result = (Boolean) settingsValidation.invoke(cliParser, settings);
+        Assert.assertTrue(result);
+
+        // user + password is also sufficient
+        settings.setBearerToken(null);
+        settings.setUser("admin");
+        settings.setPassword("password".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        result = (Boolean) settingsValidation.invoke(cliParser, settings);
         Assert.assertTrue(result);
     }
 


### PR DESCRIPTION
## Backlog item

- US #[3130040](https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=3130040)

## Description

- As in some CI systems we instruct the customers to use token-based API Accesses in order to set up some parts of the integrations, we'd like to support this kind of API Access in `octane-collection-tool` as well. Given so, the customers will have to create only one API Access of type token, for the entire setup.