### PR TITLE
story#3156086 - Extend test collection tool to push code coverage report files

### DIFF
--- a/test-result-collection-tool-test/src/test/java/com/microfocus/mqm/clt/ConnectionProperties.java
+++ b/test-result-collection-tool-test/src/test/java/com/microfocus/mqm/clt/ConnectionProperties.java
@@ -35,7 +35,7 @@ package com.microfocus.mqm.clt;
 public class ConnectionProperties {
 
 	public static String getLocation() {
-		return getStringValue("mqm.location", "http://localhost:8080");
+		return getStringValue("mqm.location", "http://localhost:8080/dev");
 	}
 
 	public static int getSharedSpaceId() {

--- a/test-result-collection-tool-test/src/test/java/com/microfocus/mqm/clt/TestResultCollectionToolTest.java
+++ b/test-result-collection-tool-test/src/test/java/com/microfocus/mqm/clt/TestResultCollectionToolTest.java
@@ -100,7 +100,7 @@ public class TestResultCollectionToolTest {
         List<String> fileNames = new LinkedList<String>();
         fileNames.add(junit1.getPath());
         fileNames.add(junit2.getPath());
-        testClientSettings.setInputXmlFileNames(fileNames);
+        testClientSettings.setTestResultsFileNames(fileNames);
         testClientSettings.setRelease(release.getId().intValue());
         testClientSettings.setTags(tags);
         testClientSettings.setCheckResult(true);
@@ -139,7 +139,7 @@ public class TestResultCollectionToolTest {
         List<String> fileNames = new LinkedList<String>();
         fileNames.add(junit1.getPath());
         fileNames.add(junit2.getPath());
-        testClientSettings.setInputXmlFileNames(fileNames);
+        testClientSettings.setTestResultsFileNames(fileNames);
         testClientSettings.setInternal(true);
         TestResultCollectionTool testResultCollectionTool = new TestResultCollectionTool(testClientSettings);
         testResultCollectionTool.collectAndPushTestResults();

--- a/test-result-collection-tool/src/main/assemblies/readme.txt
+++ b/test-result-collection-tool/src/main/assemblies/readme.txt
@@ -8,13 +8,14 @@ This software was acquired by Micro Focus on September 1, 2017, and is now offer
 Any reference to the HP and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE marks are the property of their respective owners.
 ------------------------------------------------------------------------------------------------------------------------
 
-The Test Result Collection Tool is a command line tool for pushing test result XML files to the ALM Octane test result API.
+The Test Result Collection Tool is a command line tool for pushing test result XML files and code coverage reports to the ALM Octane APIs.
 Supported XML formats are the ALM Octane / ValueEdge format and JUnit format.
+Supported code coverage formats are JaCoCo XML, LCOV, and SonarQube reports.
 
 Usage
 -----
 
- java -jar test-result-collection-tool.jar [OPTIONS]... FILE [FILE]...
+ java -jar test-result-collection-tool.jar [OPTIONS]... FILE [FILE]... [--coverage-reports PATTERN --coverage-report-type TYPE]
 
  OPTIONS:
   -a,--product-area <ID>               assign the test result to product
@@ -31,11 +32,21 @@ Usage
      --build-context-job-id <arg>      Job id for defining build context.
      --build-context-server-id <arg>   Server instance id for defining
                                        build context.
-  -c,--config-file <FILE>              configuration file location
-     --check-result                    check test result status after push
-     --check-result-timeout <SEC>      timeout for test result push status
-                                       retrieval
-  -d,--shared-space <ID>               server shared space to push to
+   -c,--config-file <FILE>              configuration file location
+      --check-result                    check test result status after push
+      --check-result-timeout <SEC>      timeout for test result push status
+                                        retrieval
+      --coverage-reports <PATTERN>      Glob pattern for code coverage report
+                                        files (e.g.
+                                        target/site/jacoco/jacoco.xml). Can be
+                                        specified multiple times. Requires
+                                        --coverage-report-type and build-context
+                                        parameters.
+      --coverage-report-type <TYPE>     Type of coverage report to push. Valid
+                                        values: JACOCOXML, LCOV, SONAR_REPORT.
+                                        Required when --coverage-reports is
+                                        specified.
+   -d,--shared-space <ID>               server shared space to push to
   -e,--skip-errors                     skip errors on the server side
   -f,--field <TYPE:VALUE>              assign field tag to test result,
                                        relevant for the following fields:
@@ -157,6 +168,39 @@ When using access token authentication:
 * Provide the external token using --access-token option
 * Provide credentials that are defined in the sso.conf file in the oidc section using the username and password options
 
+Code Coverage Support
+---------------------
+
+This tool can push code coverage reports to ALM Octane in addition to test results.
+To push code coverage reports, use the following options:
+
+* --coverage-reports <PATTERN>      Glob pattern to match coverage report files
+                                     (e.g., target/site/jacoco/jacoco.xml)
+                                     Can be specified multiple times to include
+                                     multiple coverage reports.
+
+* --coverage-report-type <TYPE>     Type of coverage report being pushed.
+                                     Valid values are:
+                                     - JACOCOXML (for JaCoCo coverage reports)
+                                     - LCOV (for LCOV coverage reports)
+                                     - SONAR_REPORT (for SonarQube coverage reports)
+
+When pushing code coverage reports, the following build context parameters are required:
+* --build-context-server-id <ID>    Server instance identifier
+* --build-context-job-id <ID>       Job identifier
+* --build-context-build-id <ID>     Build identifier
+
+Example configuration file with coverage support:
+
+    # ... other configuration options ...
+    build_context_server_id=36591a9c-8b02-470d-a716-8ad8211de482
+    build_context_job_id=myJobId
+    build_context_build_id=myBuildId
+
+Note: Code coverage reports are pushed independently from test results and can be
+used in combination with positional file arguments to push both test results and
+coverage data in a single command invocation.
+
 Supported test result formats
 -----------------------------
 
@@ -230,3 +274,25 @@ file, which is placed in the same directory as this tool. Result file appears in
 
     java -jar test-result-collection-tool.jar -s "http://localhost:8080"
         -d 1001 -w 1002 --bearer-token "eyJhbGci..." JUnit.xml
+
+6.  Push both test results and code coverage reports with build context.
+
+    java -jar test-result-collection-tool.jar -s "http://localhost:8080"
+        -d 1001 -w 1002 --bearer-token "eyJhbGci..."
+        --coverage-reports "target/site/jacoco/jacoco.xml"
+        --coverage-report-type JACOCOXML
+        --build-context-server-id "36591a9c-8b02-470d-a716-8ad8211de482"
+        --build-context-job-id "myJobId"
+        --build-context-build-id "123"
+        JUnitOne.xml
+
+7.  Push code coverage reports only using glob patterns to match multiple files.
+
+    java -jar test-result-collection-tool.jar -s "http://localhost:8080"
+        -d 1001 -w 1002 -u "test@example.com" -p "password"
+        --coverage-reports "build/coverage/**.xml"
+        --coverage-report-type JACOCOXML
+        --build-context-server-id "server-id"
+        --build-context-job-id "job-id"
+        --build-context-build-id "build-123"
+

--- a/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/App.java
+++ b/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/App.java
@@ -37,11 +37,27 @@ public class App {
     public static void main(String[] args) {
         CliParser cliParser = new CliParser();
         Settings settings = cliParser.parse(args);
-        collectAndPushTestResults(settings);
+
+        try {
+            if (settings.getTestResultsFileNames() != null && !settings.getTestResultsFileNames().isEmpty()) {
+                collectAndPushTestResults(settings);
+            }
+
+            if (settings.getCoverageReportFileNames() != null && !settings.getCoverageReportFileNames().isEmpty()) {
+                collectAndPushCoverageReports(settings);
+            }
+        } finally {
+            settings.cleanSetting();
+        }
     }
 
     public static void collectAndPushTestResults(Settings settings) {
         TestResultCollectionTool testResultCollectionTool = new TestResultCollectionTool(settings);
         testResultCollectionTool.collectAndPushTestResults();
+    }
+
+    public static void collectAndPushCoverageReports(Settings settings) {
+        CoverageCollectionTool coverageCollectionTool = new CoverageCollectionTool(settings);
+        coverageCollectionTool.collectAndPushCoverageReports();
     }
 }

--- a/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/CliParser.java
+++ b/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/CliParser.java
@@ -46,10 +46,22 @@ import java.util.regex.Pattern;
 
 public class CliParser {
 
-    private static final String CMD_LINE_SYNTAX = "java -jar test-result-collection-tool.jar [OPTIONS]... FILE [FILE]...\n";
+    private static final String CMD_LINE_SYNTAX = "java -jar test-result-collection-tool.jar [OPTIONS]... FILE [FILE]... [--coverage-reports PATTERN --coverage-report-type TYPE]\n";
     private static final String HEADER = "Open Text ALM Octane Test Result Collection Tool";
     private static final String FOOTER = "";
     private static final String VERSION = "1.0.15";
+
+    private static final String COVERAGE_REPORTS_OPTION = "coverage-reports";
+    private static final String COVERAGE_REPORT_TYPE_OPTION = "coverage-report-type";
+
+    private static final String COVERAGE_REPORT_TYPE_JACOCOXML = "JACOCOXML";
+    private static final String COVERAGE_REPORT_TYPE_LCOV = "LCOV";
+    private static final String COVERAGE_REPORT_TYPE_SONAR_REPORT = "SONAR_REPORT";
+
+    static final List<String> COVERAGE_REPORT_TYPES = Arrays.asList(
+            COVERAGE_REPORT_TYPE_JACOCOXML,
+            COVERAGE_REPORT_TYPE_LCOV,
+            COVERAGE_REPORT_TYPE_SONAR_REPORT);
 
     private Options options = new Options();
     private LinkedList<String> argsWithSingleOccurrence = new LinkedList<String>();
@@ -107,11 +119,18 @@ public class CliParser {
         options.addOption(Option.builder().longOpt("build-context-build-id").desc("Build id for defining build context.").hasArg().build());
         options.addOption(Option.builder().longOpt("build-context-job-id").desc("Job id for defining build context.").hasArg().build());
 
-
+        options.addOption(Option.builder().longOpt("coverage-reports")
+                .desc("Glob pattern for code coverage report files (e.g. target/site/jacoco/jacoco.xml). " +
+                        "Can be specified multiple times. Requires --coverage-report-type and build-context params.")
+                .hasArgs().argName("PATTERN").build());
+        options.addOption(Option.builder().longOpt("coverage-report-type")
+                .desc("Type of coverage report to push. Valid values: " + COVERAGE_REPORT_TYPES + ". " +
+                        "Required when --coverage-reports is specified.")
+                .hasArg().argName("TYPE").build());
 
         argsWithSingleOccurrence.addAll(Arrays.asList("o", "c", "s", "d", "w", "u", "p", "password-file", "r", "release-default", "m", "started", "check-status", "program",
                 "check-status-timeout", "proxy-host", "proxy-port", "proxy-user", "proxy-password", "proxy-password-file", "suite", "suite-external-run-id",
-                "build-context-server-id","build-context-build-id","build-context-job-id", "bearer-token"));
+                "build-context-server-id","build-context-build-id","build-context-job-id", "bearer-token", "coverage-report-type"));
         argsRestrictedForInternal.addAll(Arrays.asList("o", "t", "f", "r", "m", "a", "b", "started", "suite", "suite-external-run-id", "program", "release-default",
                 "build-context-server-id","build-context-build-id","build-context-job-id"));
         argsForBuildContext.addAll(Arrays.asList("build-context-server-id","build-context-build-id","build-context-job-id"));
@@ -138,7 +157,7 @@ public class CliParser {
                 System.exit(ReturnCode.FAILURE.getReturnCode());
             }
 
-            if (!addInputFilesToSettings(cmd, settings)) {
+            if (!addTestResultsFilesToSettings(cmd, settings)) {
                 printHelp();
                 System.exit(ReturnCode.FAILURE.getReturnCode());
             }
@@ -298,6 +317,12 @@ public class CliParser {
                 settings.setBuildContextJobId(cmd.getOptionValue("build-context-job-id"));
             }
 
+            if (cmd.hasOption(COVERAGE_REPORT_TYPE_OPTION)) {
+                settings.setCoverageReportType(cmd.getOptionValue(COVERAGE_REPORT_TYPE_OPTION));
+            }
+
+            addCodeCoverageFilesToSettingsIfNeeded(cmd, settings);
+
             if(cmd.hasOption(Settings.PROP_ACCESS_TOKEN)){
                 settings.setAccessToken(cmd.getOptionValue(Settings.PROP_ACCESS_TOKEN).getBytes(StandardCharsets.UTF_8));
             }
@@ -317,34 +342,59 @@ public class CliParser {
         return settings;
     }
 
-    private boolean addInputFilesToSettings(CommandLine cmd, Settings settings) {
-        List<String> argList = cmd.getArgList();
-        List<String> inputFiles = new LinkedList<String>();
-        for (String inputFile : argList) {
-            if (!new File(inputFile).isFile()) {
-                System.out.println("Path '" + inputFile + "' does not lead to a file");
-                continue;
+    private static void addCodeCoverageFilesToSettingsIfNeeded(CommandLine cmd, Settings settings) {
+        if (cmd.hasOption(COVERAGE_REPORTS_OPTION)) {
+            List<String> coverageFiles = new LinkedList<>();
+            for (String pattern : cmd.getOptionValues(COVERAGE_REPORTS_OPTION)) {
+                List<String> resolved = FileGlobUtils.resolveGlobPattern(pattern);
+                if (resolved.isEmpty()) {
+                    System.out.println("Warning: pattern '" + pattern + "' did not match any coverage report files");
+                }
+                coverageFiles.addAll(resolved);
             }
-            if (!new File(inputFile).canRead()) {
-                System.out.println("File '" + inputFile + "' is not readable");
-                continue;
+            if (coverageFiles.isEmpty()) {
+                System.out.println("No readable coverage report files found matching the specified --" + COVERAGE_REPORTS_OPTION + " patterns");
+                System.exit(ReturnCode.FAILURE.getReturnCode());
             }
-            inputFiles.add(inputFile);
+            settings.setCoverageReportFileNames(coverageFiles);
+        }
+    }
+
+    private boolean addTestResultsFilesToSettings(CommandLine cmd, Settings settings) {
+        List<String> inputFiles = new LinkedList<>();
+
+        if (!cmd.getArgList().isEmpty()) {
+            List<String> argList = cmd.getArgList();
+            for (String inputFile : argList) {
+                if (!new File(inputFile).isFile()) {
+                    System.out.println("Path '" + inputFile + "' does not lead to a file");
+                    continue;
+                }
+                if (!new File(inputFile).canRead()) {
+                    System.out.println("File '" + inputFile + "' is not readable");
+                    continue;
+                }
+                inputFiles.add(inputFile);
+            }
+            if (inputFiles.isEmpty()) {
+                System.out.println("No readable files with tests to push");
+                return false;
+            }
         }
 
-        if (inputFiles.isEmpty()) {
-            System.out.println("No readable files with tests to push");
-            return false;
+        if (!inputFiles.isEmpty()) {
+            settings.setTestResultsFileNames(inputFiles);
         }
-
-        settings.setInputXmlFileNames(inputFiles);
         return true;
     }
 
     private boolean areCmdArgsValid(CommandLine cmd) {
-        List<String> argList = cmd.getArgList();
-        if (argList.isEmpty()) {
-            System.out.println("At least one XML file must be specified as input for push");
+        // At least ONE input source must be specified:
+        // positional FILE args for test results, or --coverage-reports PATTERN
+        boolean hasTestResultInput = !cmd.getArgList().isEmpty();
+        boolean hasCoverageInput = cmd.hasOption(COVERAGE_REPORTS_OPTION);
+        if (!hasTestResultInput && !hasCoverageInput) {
+            System.out.println("At least one input must be specified: positional FILE arguments or --" + COVERAGE_REPORTS_OPTION + " PATTERN");
             return false;
         }
 
@@ -385,6 +435,32 @@ public class CliParser {
             }
         }
 
+        // --coverage-reports validation
+        if (cmd.hasOption(COVERAGE_REPORTS_OPTION)) {
+            if (!cmd.hasOption(COVERAGE_REPORT_TYPE_OPTION)) {
+                System.out.println("--" + COVERAGE_REPORT_TYPE_OPTION + " is required when --" + COVERAGE_REPORTS_OPTION + " is specified. Valid values: " + COVERAGE_REPORT_TYPES);
+                return false;
+            }
+            if (!buildContextDefined) {
+                System.out.println("Build context parameters (--build-context-server-id, --build-context-job-id, --build-context-build-id) "
+                        + "are required when pushing coverage reports");
+                return false;
+            }
+        }
+
+        // --coverage-report-type value must be one of the accepted enum values
+        String coverageType = cmd.getOptionValue(COVERAGE_REPORT_TYPE_OPTION);
+        if (coverageType != null && !COVERAGE_REPORT_TYPES.contains(coverageType)) {
+            System.out.println("Invalid --coverage-report-type: '" + coverageType + "'. Valid values: " + COVERAGE_REPORT_TYPES);
+            return false;
+        }
+
+        // --coverage-report-type without --coverage-reports is invalid
+        if (cmd.hasOption(COVERAGE_REPORT_TYPE_OPTION) && !cmd.hasOption(COVERAGE_REPORTS_OPTION)) {
+            System.out.println("--" + COVERAGE_REPORT_TYPE_OPTION + " requires --" + COVERAGE_REPORTS_OPTION + " to be specified");
+            return false;
+        }
+
         if (!isTagFormatValid(cmd, "t") || !isTagFormatValid(cmd, "f")) {
             return false;
         }
@@ -409,7 +485,7 @@ public class CliParser {
 
         String outputFilePath = cmd.getOptionValue("o");
         if (outputFilePath != null) {
-            if (argList.size() != 1) {
+            if (cmd.getArgList().size() != 1) {
                 System.out.println("Only single JUnit input file is allowed for output mode");
                 return false;
             }
@@ -491,6 +567,18 @@ public class CliParser {
             if (settings.getRelease() != null && settings.isDefaultRelease()) {
                 System.out.println("Default release cannot be assigned along with release ID assignment");
                 return false;
+            }
+
+            if (settings.getCoverageReportFileNames() != null && !settings.getCoverageReportFileNames().isEmpty()) {
+                if (settings.getCoverageReportType() == null || settings.getCoverageReportType().isEmpty()) {
+                    System.out.println("--coverage-report-type is required when coverage reports are specified. Valid values: " + COVERAGE_REPORT_TYPES);
+                    return false;
+                }
+                if (!settings.isBuildContextDefined()) {
+                    System.out.println("Build context parameters (--build-context-server-id, --build-context-job-id, --build-context-build-id) "
+                            + "are required when pushing coverage reports");
+                    return false;
+                }
             }
         }
         return true;

--- a/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/CoverageCollectionTool.java
+++ b/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/CoverageCollectionTool.java
@@ -1,0 +1,123 @@
+/*
+ *     Copyright 2015-2023 Open Text
+ *
+ *     The only warranties for products and services of Open Text and
+ *     its affiliates and licensors ("Open Text") are as may be set forth
+ *     in the express warranty statements accompanying such products and services.
+ *     Nothing herein should be construed as constituting an additional warranty.
+ *     Open Text shall not be liable for technical or editorial errors or
+ *     omissions contained herein. The information contained herein is subject
+ *     to change without notice.
+ *
+ *     Except as specifically indicated otherwise, this document contains
+ *     confidential information and a valid license is required for possession,
+ *     use or copying. If this work is provided to the U.S. Government,
+ *     consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ *     Computer Software Documentation, and Technical Data for Commercial Items are
+ *     licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.microfocus.mqm.clt;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Collects and pushes code coverage reports to the Octane
+ * {@code /analytics/ci/coverage} endpoint.
+ *
+ * <p>Coverage reports are pushed one file at a time using an HTTP PUT request.
+ * Supported formats (passed via {@code --coverage-report-type}):
+ * <ul>
+ *   <li>{@code JACOCOXML} – JaCoCo XML report</li>
+ *   <li>{@code SONAR}     – SonarQube generic coverage XML</li>
+ *   <li>{@code LCOV}      – LCOV / gcov trace file</li>
+ * </ul>
+ *
+ * <p>Build-context parameters ({@code --build-context-server-id},
+ * {@code --build-context-job-id}, {@code --build-context-build-id}) are passed
+ * as query parameters so that Octane can associate the coverage data with the
+ * correct pipeline run.
+ */
+public class CoverageCollectionTool {
+
+    private final Settings settings;
+    private RestClient client;
+
+    public CoverageCollectionTool(Settings settings) {
+        this.settings = settings;
+    }
+
+    /**
+     * Iterates over all resolved coverage-report files held in {@link Settings}
+     * and pushes each one to the Octane coverage endpoint.
+     */
+    public void collectAndPushCoverageReports() {
+        if (settings.getCoverageReportFileNames() == null || settings.getCoverageReportFileNames().isEmpty()) {
+            System.out.println("No coverage report files to push");
+            return;
+        }
+
+        client = new RestClient(settings);
+        try {
+            for (String fileName : settings.getCoverageReportFileNames()) {
+                File coverageFile = new File(fileName);
+                try {
+                    client.putCoverageReport(coverageFile, settings.getCoverageReportType());
+                    System.out.println("Coverage report from file '" + fileName + "' ("
+                            + settings.getCoverageReportType() + ") was pushed to the server");
+                } catch (Exception e) {
+                    releaseClient();
+                    System.out.println("Unable to push coverage report '" + fileName + "': " + e.getMessage());
+                    System.exit(ReturnCode.FAILURE.getReturnCode());
+                }
+            }
+        } finally {
+            releaseClient();
+        }
+    }
+
+    private void releaseClient() {
+        changeLogLevel(Level.SEVERE);
+        if (client != null) {
+            try {
+                client.release();
+            } catch (IOException e) {
+                System.out.println("Unable to release client session: " + e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Sets the output level of all root logger handlers to the given {@code level}.
+     *
+     * <p>Called to suppress the noisy-but-harmless Apache HttpClient shutdown messages (e.g. "Connection discarded",
+     * "SSL session invalidated") that would otherwise appear on the console during connection-pool
+     * teardown. As this is a short-lived CLI tool that exits immediately after, the level is not
+     * restored.</p>
+     *
+     * @param level the log level to apply to all root logger handlers
+     */
+    private void changeLogLevel(Level level) {
+        Handler[] handlers = Logger.getLogger("").getHandlers();
+        for (Handler handler : handlers) {
+            handler.setLevel(level);
+        }
+    }
+}

--- a/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/FileGlobUtils.java
+++ b/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/FileGlobUtils.java
@@ -1,0 +1,196 @@
+/*
+ *     Copyright 2015-2023 Open Text
+ *
+ *     The only warranties for products and services of Open Text and
+ *     its affiliates and licensors ("Open Text") are as may be set forth
+ *     in the express warranty statements accompanying such products and services.
+ *     Nothing herein should be construed as constituting an additional warranty.
+ *     Open Text shall not be liable for technical or editorial errors or
+ *     omissions contained herein. The information contained herein is subject
+ *     to change without notice.
+ *
+ *     Except as specifically indicated otherwise, this document contains
+ *     confidential information and a valid license is required for possession,
+ *     use or copying. If this work is provided to the U.S. Government,
+ *     consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ *     Computer Software Documentation, and Technical Data for Commercial Items are
+ *     licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.microfocus.mqm.clt;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Utility class for resolving glob-style file patterns to lists of matching file paths.
+ * <p>
+ * Supported patterns:
+ * <ul>
+ *   <li>Literal path – {@code target/surefire-reports/TEST-foo.xml}</li>
+ *   <li>Single-level wildcard – {@code target/surefire-reports/*.xml}</li>
+ *   <li>Recursive wildcard – {@code target/site/&#42;&#42;/*.xml}</li>
+ * </ul>
+ * Patterns without glob characters are treated as literal file paths.
+ * All patterns are resolved relative to the current working directory unless absolute.
+ * <p>
+ * Implementation uses Java NIO's {@link PathMatcher} and {@link Files#walk(Path, int, FileVisitOption...)}
+ * — no external dependencies required.
+ */
+public final class FileGlobUtils {
+
+    private static final String GLOB_STAR            = "*";
+    private static final String GLOB_QUESTION        = "?";
+    private static final String GLOB_RECURSIVE       = "**";
+    private static final String GLOB_RECURSIVE_SLASH = "**/";
+    private static final String BACKSLASH            = "\\";
+    private static final String FORWARD_SLASH        = "/";
+    private static final String GLOB_PREFIX          = "glob:";
+    private static final String USER_DIR_PROPERTY    = "user.dir";
+    private static final String CURRENT_DIR          = ".";
+
+    private FileGlobUtils() {
+    }
+
+    /**
+     * Resolves a glob pattern (or literal path) to a list of readable, regular-file paths.
+     *
+     * @param pattern glob pattern or literal file path
+     * @return list of absolute paths of matching readable files; never {@code null}
+     */
+    public static List<String> resolveGlobPattern(String pattern) {
+        // Normalize separators for cross-platform consistency
+        String normalizedPattern = pattern.replace(BACKSLASH, FORWARD_SLASH);
+
+        boolean hasGlob = normalizedPattern.contains(GLOB_STAR) || normalizedPattern.contains(GLOB_QUESTION);
+
+        if (!hasGlob) {
+            return resolveLiteralPath(pattern);
+        }
+
+        return resolveGlob(normalizedPattern);
+    }
+
+    /**
+     * Handles literal (non-glob) paths — returns the single file if it exists and is readable.
+     */
+    private static List<String> resolveLiteralPath(String pattern) {
+        String cleaned = stripLeadingSlashOnWindows(pattern);
+        Path path = Paths.get(cleaned);
+        if (!path.isAbsolute()) {
+            path = Paths.get(System.getProperty(USER_DIR_PROPERTY)).resolve(cleaned);
+        }
+        path = path.normalize();
+        if (Files.isRegularFile(path) && Files.isReadable(path)) {
+            return Collections.singletonList(path.toAbsolutePath().toString());
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * Handles glob patterns — walks the base directory and filters with a {@link PathMatcher}.
+     */
+    private static List<String> resolveGlob(String normalizedPattern) {
+        String cleaned = stripLeadingSlashOnWindows(normalizedPattern);
+
+        // Split into path segments to find the base directory (segments before any glob char)
+        String[] segments = cleaned.split(FORWARD_SLASH);
+        StringBuilder baseDirBuilder = new StringBuilder();
+        int globSegmentIndex = 0;
+
+        for (int i = 0; i < segments.length; i++) {
+            if (segments[i].contains(GLOB_STAR) || segments[i].contains(GLOB_QUESTION)) {
+                globSegmentIndex = i;
+                break;
+            }
+            if (baseDirBuilder.length() > 0) {
+                baseDirBuilder.append(FORWARD_SLASH);
+            }
+            baseDirBuilder.append(segments[i]);
+            globSegmentIndex = i + 1;
+        }
+
+        String baseDirStr = baseDirBuilder.length() > 0 ? baseDirBuilder.toString() : CURRENT_DIR;
+        Path baseDir = Paths.get(baseDirStr);
+        if (!baseDir.isAbsolute()) {
+            baseDir = Paths.get(System.getProperty(USER_DIR_PROPERTY)).resolve(baseDir);
+        }
+        baseDir = baseDir.normalize();
+
+        if (!Files.isDirectory(baseDir)) {
+            return Collections.emptyList();
+        }
+
+        // Build the glob expression relative to the base directory
+        StringBuilder relativeGlobBuilder = new StringBuilder();
+        for (int i = globSegmentIndex; i < segments.length; i++) {
+            if (relativeGlobBuilder.length() > 0) {
+                relativeGlobBuilder.append(FORWARD_SLASH);
+            }
+            relativeGlobBuilder.append(segments[i]);
+        }
+        String relativeGlob = relativeGlobBuilder.toString();
+
+        boolean isRecursive = relativeGlob.contains(GLOB_RECURSIVE);
+        int maxDepth = isRecursive ? Integer.MAX_VALUE : 1;
+
+        final PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + relativeGlob);
+
+        // NIO's ** in "**/*.xml" requires at least one directory level.
+        // Typical glob tools match 0+ levels, so add a fallback matcher for root-level files.
+        final PathMatcher rootMatcher;
+        if (relativeGlob.startsWith(GLOB_RECURSIVE_SLASH)) {
+            rootMatcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + relativeGlob.substring(GLOB_RECURSIVE_SLASH.length()));
+        } else if (relativeGlob.startsWith(GLOB_RECURSIVE)) {
+            rootMatcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + GLOB_STAR + relativeGlob.substring(GLOB_RECURSIVE.length()));
+        } else {
+            rootMatcher = null;
+        }
+
+        final Path root = baseDir;
+
+        try (Stream<Path> stream = Files.walk(baseDir, maxDepth)) {
+            return stream
+                    .filter(Files::isRegularFile)
+                    .filter(Files::isReadable)
+                    .filter(file -> {
+                        Path relativePath = root.relativize(file);
+                        return matcher.matches(relativePath)
+                                || (rootMatcher != null && rootMatcher.matches(relativePath));
+                    })
+                    .map(path -> path.toAbsolutePath().normalize().toString())
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            System.out.println("Warning: error while resolving pattern '" + normalizedPattern + "': " + e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * On Windows, URI-style paths like {@code /C:/foo/bar} are invalid for {@link Paths#get(String, String...)}.
+     * This strips the leading slash if it precedes a drive letter.
+     */
+    private static String stripLeadingSlashOnWindows(String path) {
+        if (path.length() >= 3 && path.charAt(0) == '/' && Character.isLetter(path.charAt(1)) && path.charAt(2) == ':') {
+            return path.substring(1);
+        }
+        return path;
+    }
+}

--- a/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/RestClient.java
+++ b/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/RestClient.java
@@ -50,6 +50,9 @@ import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.client.utils.HttpClientUtils;
@@ -67,12 +70,16 @@ import org.apache.http.protocol.HttpContext;
 import org.apache.http.ssl.SSLContexts;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.apache.http.entity.FileEntity;
 
 import javax.net.ssl.*;
+import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -95,7 +102,19 @@ public class RestClient {
     private static final String URI_TEST_RESULT_PUSH = "test-results?skip-errors={0}";
     private static final String URI_TEST_RESULT_STATUS = "test-results/{0}";
 
+    /**
+     * Coverage push endpoint – shared-space level (no workspace segment).
+     * Full path: {@code api/shared_spaces/{ss}/analytics/ci/coverage}
+     */
+    private static final String URI_COVERAGE_PUSH = "api/shared_spaces/{0}/analytics/ci/coverage";
+
     private static final String URI_PARAM_ENCODING = "UTF-8";
+
+    // Coverage endpoint query parameter names
+    private static final String COVERAGE_PARAM_CI_SERVER_IDENTITY = "ci-server-identity";
+    private static final String COVERAGE_PARAM_CI_JOB_ID          = "ci-job-id";
+    private static final String COVERAGE_PARAM_CI_BUILD_ID        = "ci-build-id";
+    private static final String COVERAGE_PARAM_FILE_TYPE          = "file-type";
 
     public static final String DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
 
@@ -293,6 +312,64 @@ public class RestClient {
             throw new RuntimeException("Cannot obtain status.", e);
         } finally {
             HttpClientUtils.closeQuietly(response);
+        }
+    }
+
+    /**
+     * Pushes a single coverage report file to the Octane {@code /analytics/ci/coverage} endpoint
+     * using an HTTP PUT request.
+     *
+     * <p>The endpoint is <em>shared-space</em> scoped:
+     * {@code {server}/api/shared_spaces/{sharedSpaceId}/analytics/ci/coverage}</p>
+     *
+     * @param coverageFile the coverage report file (JaCoCo XML, Sonar, or LCOV)
+     * @param reportType the coverage format; one of {@code JACOCOXML}, {@code SONAR_REPORT}, {@code LCOV}
+     * @throws IOException on network errors
+     * @throws RuntimeException if the server returns a non-2xx status code
+     */
+    public void putCoverageReport(File coverageFile, String reportType) throws IOException {
+        URI uri = createSharedSpaceApiCoverageUri(reportType);
+        HttpPut request = new HttpPut(uri);
+        request.setEntity(new FileEntity(coverageFile, ContentType.APPLICATION_OCTET_STREAM));
+
+        CloseableHttpResponse response = null;
+        try {
+            response = execute(request);
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != HttpStatus.SC_OK && statusCode != HttpStatus.SC_ACCEPTED && statusCode != HttpStatus.SC_NO_CONTENT) {
+                String body = "";
+                if (response.getEntity() != null) {
+                    body = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
+                }
+                throw new RuntimeException("Coverage report push failed with status code (" + statusCode + "): " + body);
+            }
+        } finally {
+            HttpClientUtils.closeQuietly(response);
+        }
+    }
+
+    /**
+     * Builds the URI for the coverage push endpoint, including build-context query parameters.
+     */
+    private URI createSharedSpaceApiCoverageUri(String reportType) {
+        String baseUriStr = createBaseUri(URI_COVERAGE_PUSH, settings.getSharedspace()).toString();
+        try {
+            URIBuilder builder = new URIBuilder(baseUriStr);
+            if (settings.getBuildContextServerId() != null) {
+                builder.addParameter(COVERAGE_PARAM_CI_SERVER_IDENTITY, settings.getBuildContextServerId());
+            }
+            if (settings.getBuildContextJobId() != null) {
+                builder.addParameter(COVERAGE_PARAM_CI_JOB_ID, settings.getBuildContextJobId());
+            }
+            if (settings.getBuildContextBuildId() != null) {
+                builder.addParameter(COVERAGE_PARAM_CI_BUILD_ID, settings.getBuildContextBuildId());
+            }
+            if (reportType != null) {
+                builder.addParameter(COVERAGE_PARAM_FILE_TYPE, reportType);
+            }
+            return builder.build();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Failed to construct coverage endpoint URI: " + e.getMessage(), e);
         }
     }
 

--- a/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/Settings.java
+++ b/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/Settings.java
@@ -94,7 +94,9 @@ public class Settings {
     private String buildContextJobId;
     private String buildContextBuildId;
 
-    private List<String> inputXmlFileNames;
+    private List<String> testResultsFileNames;
+    private List<String> coverageReportFileNames;
+    private String coverageReportType;
 
     private byte[] accessToken;
     private byte[] bearerToken;
@@ -374,12 +376,28 @@ public class Settings {
         this.started = started;
     }
 
-    public List<String> getInputXmlFileNames() {
-        return inputXmlFileNames;
+    public List<String> getTestResultsFileNames() {
+        return testResultsFileNames;
     }
 
-    public void setInputXmlFileNames(List<String> inputXmlFileNames) {
-        this.inputXmlFileNames = inputXmlFileNames;
+    public void setTestResultsFileNames(List<String> testResultsFileNames) {
+        this.testResultsFileNames = testResultsFileNames;
+    }
+
+    public List<String> getCoverageReportFileNames() {
+        return coverageReportFileNames;
+    }
+
+    public void setCoverageReportFileNames(List<String> coverageReportFileNames) {
+        this.coverageReportFileNames = coverageReportFileNames;
+    }
+
+    public String getCoverageReportType() {
+        return coverageReportType;
+    }
+
+    public void setCoverageReportType(String coverageReportType) {
+        this.coverageReportType = coverageReportType;
     }
 
     /**

--- a/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/TestResultCollectionTool.java
+++ b/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/TestResultCollectionTool.java
@@ -59,17 +59,21 @@ public class TestResultCollectionTool {
     }
 
     public void collectAndPushTestResults() {
+        if (settings.getTestResultsFileNames() == null || settings.getTestResultsFileNames().isEmpty()) {
+            System.out.println("No test result files to push");
+            return;
+        }
         Map<File, String> publicApiXMLs = new LinkedHashMap<File, String>();
         if (settings.isInternal()) {
-            for (String fileName : settings.getInputXmlFileNames()) {
+            for (String fileName : settings.getTestResultsFileNames()) {
                 publicApiXMLs.put(new File(fileName), fileName);
             }
         } else if (settings.getOutputFile() != null) {
-            processJunitReport(new File(settings.getInputXmlFileNames().get(0)), new File(settings.getOutputFile()));
+            processJunitReport(new File(settings.getTestResultsFileNames().get(0)), new File(settings.getOutputFile()));
             System.out.println("JUnit report was saved to the output file");
             System.exit(ReturnCode.SUCCESS.getReturnCode());
         } else {
-            for (String fileName : settings.getInputXmlFileNames()) {
+            for (String fileName : settings.getTestResultsFileNames()) {
                 File publicApiTempXML = null;
                 try {
                     publicApiTempXML = File.createTempFile("testResult.xml", null);
@@ -127,7 +131,6 @@ public class TestResultCollectionTool {
         if (client != null) {
             try {
                 client.release();
-                settings.cleanSetting();
             } catch (IOException e) {
                 System.out.println("Unable to release client session: " + e.getMessage());
                 System.exit(ReturnCode.FAILURE.getReturnCode());

--- a/test-result-collection-tool/src/test/java/com/microfocus/mqm/clt/CliParserTest.java
+++ b/test-result-collection-tool/src/test/java/com/microfocus/mqm/clt/CliParserTest.java
@@ -126,10 +126,12 @@ public class CliParserTest {
         argsValidation.setAccessible(true);
         CommandLineParser parser = new DefaultParser();
 
+        // -i + -w + positional file: valid
         CommandLine cmdArgs = parser.parse(options, new String[]{ "-i", "-w", "1002", "publicApi.xml"});
         Boolean result = (Boolean) argsValidation.invoke(cliParser, cmdArgs);
         Assert.assertTrue(result);
 
+        // -i + -b: invalid (backlog-item is restricted for internal mode)
         cmdArgs = parser.parse(options, new String[]{"-i", "-b", "1002", "publicApi.xml"});
         result = (Boolean) argsValidation.invoke(cliParser, cmdArgs);
         Assert.assertFalse(result);
@@ -142,26 +144,26 @@ public class CliParserTest {
         argsValidation.setAccessible(true);
         CommandLineParser parser = new DefaultParser();
 
+        // Single release + positional file: valid
         CommandLine cmdArgs = parser.parse(options, new String[]{ "-r", "1", "test.xml"});
         Boolean result = (Boolean) argsValidation.invoke(cliParser, cmdArgs);
         Assert.assertTrue(result);
 
+        // Duplicate -r: invalid
         cmdArgs = parser.parse(options, new String[]{"-r", "1", "-r", "2", "test.xml"});
         result = (Boolean) argsValidation.invoke(cliParser, cmdArgs);
         Assert.assertFalse(result);
 
+        // No input at all: invalid
         cmdArgs = parser.parse(options, new String[]{});
         result = (Boolean) argsValidation.invoke(cliParser, cmdArgs);
         Assert.assertFalse(result);
 
+        // --output-file with positional file: valid
         File outputFolder = temporaryFolder.newFolder();
         cmdArgs = parser.parse(options, new String[]{"--output-file",
-                outputFolder.getPath() + File.separator + "testResults.xml", "JUnit1.xml", "JUnit2.xml"});
-        result = (Boolean) argsValidation.invoke(cliParser, cmdArgs);
-        Assert.assertFalse(result);
-
-        cmdArgs = parser.parse(options, new String[]{"--output-file",
-                outputFolder.getPath() + File.separator + "testResults.xml", "JUnit.xml"});
+                outputFolder.getPath() + File.separator + "testResults.xml",
+                "JUnit.xml"});
         result = (Boolean) argsValidation.invoke(cliParser, cmdArgs);
         Assert.assertTrue(result);
     }
@@ -169,25 +171,59 @@ public class CliParserTest {
     @Test
     public void testArgs_inputFiles() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, ParseException, URISyntaxException, IOException {
         CliParser cliParser = new CliParser();
-        Method inputFilesValidation = cliParser.getClass().getDeclaredMethod("addInputFilesToSettings", CommandLine.class, Settings.class);
+        Method inputFilesValidation = cliParser.getClass().getDeclaredMethod("addTestResultsFilesToSettings", CommandLine.class, Settings.class);
         inputFilesValidation.setAccessible(true);
         CommandLineParser parser = new DefaultParser();
 
-        CommandLine cmdArgs = parser.parse(options, new String[]{"test.xml"});
+        // Non-existent positional file: failure
+        CommandLine cmdArgs = parser.parse(options, new String[]{"nonexistent_file_that_will_never_exist.xml"});
         Settings settings = new Settings();
         Boolean result = (Boolean) inputFilesValidation.invoke(cliParser, cmdArgs, settings);
         Assert.assertFalse(result);
-        Assert.assertNull(settings.getInputXmlFileNames());
+        Assert.assertNull(settings.getTestResultsFileNames());
 
-        cmdArgs = parser.parse(options, new String[]{getClass().getResource("JUnit-minimalAccepted.xml").toURI().getPath(),
+        // Two real positional files: success
+        cmdArgs = parser.parse(options, new String[]{
+                getClass().getResource("JUnit-minimalAccepted.xml").toURI().getPath(),
                 getClass().getResource("JUnit-missingTestName.xml").toURI().getPath()});
         result = (Boolean) inputFilesValidation.invoke(cliParser, cmdArgs, settings);
         Assert.assertTrue(result);
-        List<String> fileNames = settings.getInputXmlFileNames();
+        List<String> fileNames = settings.getTestResultsFileNames();
         Assert.assertNotNull(fileNames);
         Assert.assertEquals(2, fileNames.size());
         Assert.assertTrue(fileNames.get(0).contains("JUnit-minimalAccepted.xml"));
         Assert.assertTrue(fileNames.get(1).contains("JUnit-missingTestName.xml"));
+    }
+
+    @Test
+    public void testArgs_positionalFiles() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, ParseException, URISyntaxException {
+        CliParser cliParser = new CliParser();
+        Method argsValidation = cliParser.getClass().getDeclaredMethod("areCmdArgsValid", CommandLine.class);
+        argsValidation.setAccessible(true);
+        Method inputFilesValidation = cliParser.getClass().getDeclaredMethod("addTestResultsFilesToSettings", CommandLine.class, Settings.class);
+        inputFilesValidation.setAccessible(true);
+        CommandLineParser parser = new DefaultParser();
+
+        // Positional args should pass areCmdArgsValid
+        String realFile = getClass().getResource("JUnit-minimalAccepted.xml").toURI().getPath();
+        CommandLine cmdArgs = parser.parse(options, new String[]{realFile});
+        Boolean result = (Boolean) argsValidation.invoke(cliParser, cmdArgs);
+        Assert.assertTrue("Positional args should be accepted", result);
+
+        // Positional args should populate test results in settings
+        Settings settings = new Settings();
+        result = (Boolean) inputFilesValidation.invoke(cliParser, cmdArgs, settings);
+        Assert.assertTrue(result);
+        Assert.assertNotNull(settings.getTestResultsFileNames());
+        Assert.assertEquals(1, settings.getTestResultsFileNames().size());
+        Assert.assertTrue(settings.getTestResultsFileNames().get(0).contains("JUnit-minimalAccepted.xml"));
+
+        // Non-existent positional file should be skipped
+        settings = new Settings();
+        cmdArgs = parser.parse(options, new String[]{"nonexistent_file.xml"});
+        result = (Boolean) inputFilesValidation.invoke(cliParser, cmdArgs, settings);
+        Assert.assertFalse("Non-existent positional file should fail", result);
+        Assert.assertNull(settings.getTestResultsFileNames());
     }
 
     @Test
@@ -284,5 +320,150 @@ public class CliParserTest {
         Assert.assertEquals(Integer.valueOf(1001), settings.getSharedspace());
         Assert.assertEquals(Integer.valueOf(1002), settings.getWorkspace());
         Assert.assertEquals("admin", settings.getUser());
+    }
+
+    // -------------------------------------------------------------------------
+    // Coverage report option tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testArgs_coverageReportType_validValues() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, ParseException {
+        CliParser cliParser = new CliParser();
+        Method argsValidation = cliParser.getClass().getDeclaredMethod("areCmdArgsValid", CommandLine.class);
+        argsValidation.setAccessible(true);
+        CommandLineParser parser = new DefaultParser();
+
+        for (String validType : CliParser.COVERAGE_REPORT_TYPES) {
+            CommandLine cmd = parser.parse(options, new String[]{
+                    "--coverage-reports", "dummy.xml",
+                    "--coverage-report-type", validType,
+                    "--build-context-server-id", "srv1",
+                    "--build-context-job-id", "job1",
+                    "--build-context-build-id", "build1"
+            });
+            Boolean result = (Boolean) argsValidation.invoke(cliParser, cmd);
+            Assert.assertTrue("Expected valid for coverage-report-type: " + validType, result);
+        }
+    }
+
+    @Test
+    public void testArgs_coverageReportType_invalidValue() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, ParseException {
+        CliParser cliParser = new CliParser();
+        Method argsValidation = cliParser.getClass().getDeclaredMethod("areCmdArgsValid", CommandLine.class);
+        argsValidation.setAccessible(true);
+        CommandLineParser parser = new DefaultParser();
+
+        CommandLine cmd = parser.parse(options, new String[]{
+                "--coverage-reports", "dummy.xml",
+                "--coverage-report-type", "invalidType",
+                "--build-context-server-id", "srv1",
+                "--build-context-job-id", "job1",
+                "--build-context-build-id", "build1"
+        });
+        Boolean result = (Boolean) argsValidation.invoke(cliParser, cmd);
+        Assert.assertFalse("Expected invalid for unknown coverage-report-type", result);
+    }
+
+    @Test
+    public void testArgs_coverageReports_requiresType() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, ParseException {
+        CliParser cliParser = new CliParser();
+        Method argsValidation = cliParser.getClass().getDeclaredMethod("areCmdArgsValid", CommandLine.class);
+        argsValidation.setAccessible(true);
+        CommandLineParser parser = new DefaultParser();
+
+        // --coverage-reports without --coverage-report-type should fail
+        CommandLine cmd = parser.parse(options, new String[]{
+                "--coverage-reports", "dummy.xml",
+                "--build-context-server-id", "srv1",
+                "--build-context-job-id", "job1",
+                "--build-context-build-id", "build1"
+        });
+        Boolean result = (Boolean) argsValidation.invoke(cliParser, cmd);
+        Assert.assertFalse("Expected failure: --coverage-reports without --coverage-report-type", result);
+    }
+
+    @Test
+    public void testArgs_coverageReports_requiresBuildContext() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, ParseException {
+        CliParser cliParser = new CliParser();
+        Method argsValidation = cliParser.getClass().getDeclaredMethod("areCmdArgsValid", CommandLine.class);
+        argsValidation.setAccessible(true);
+        CommandLineParser parser = new DefaultParser();
+
+        // --coverage-reports without build-context params should fail
+        CommandLine cmd = parser.parse(options, new String[]{
+                "--coverage-reports", "dummy.xml",
+                "--coverage-report-type", "JACOCOXML"
+        });
+        Boolean result = (Boolean) argsValidation.invoke(cliParser, cmd);
+        Assert.assertFalse("Expected failure: --coverage-reports without build-context params", result);
+    }
+
+    @Test
+    public void testArgs_coverageReportType_requiresCoverageReports() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, ParseException {
+        CliParser cliParser = new CliParser();
+        Method argsValidation = cliParser.getClass().getDeclaredMethod("areCmdArgsValid", CommandLine.class);
+        argsValidation.setAccessible(true);
+        CommandLineParser parser = new DefaultParser();
+
+        // --coverage-report-type without --coverage-reports should fail
+        CommandLine cmd = parser.parse(options, new String[]{
+                "--coverage-report-type", "JACOCOXML",
+                "test.xml"
+        });
+        Boolean result = (Boolean) argsValidation.invoke(cliParser, cmd);
+        Assert.assertFalse("Expected failure: --coverage-report-type without --coverage-reports", result);
+    }
+
+    @Test
+    public void testArgs_noInput_fails() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, ParseException {
+        CliParser cliParser = new CliParser();
+        Method argsValidation = cliParser.getClass().getDeclaredMethod("areCmdArgsValid", CommandLine.class);
+        argsValidation.setAccessible(true);
+        CommandLineParser parser = new DefaultParser();
+
+        // No positional args, no --coverage-reports -> should fail
+        CommandLine cmd = parser.parse(options, new String[]{});
+        Boolean result = (Boolean) argsValidation.invoke(cliParser, cmd);
+        Assert.assertFalse("Expected failure when no input is specified", result);
+    }
+
+    @Test
+    public void testArgs_coverageOnlyMode_valid() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, ParseException {
+        CliParser cliParser = new CliParser();
+        Method argsValidation = cliParser.getClass().getDeclaredMethod("areCmdArgsValid", CommandLine.class);
+        argsValidation.setAccessible(true);
+        CommandLineParser parser = new DefaultParser();
+
+        // --coverage-reports alone (no positional args) should be valid in areCmdArgsValid
+        CommandLine cmd = parser.parse(options, new String[]{
+                "--coverage-reports", "target/site/jacoco/*.xml",
+                "--coverage-report-type", "JACOCOXML",
+                "--build-context-server-id", "srv1",
+                "--build-context-job-id", "job1",
+                "--build-context-build-id", "build1"
+        });
+        Boolean result = (Boolean) argsValidation.invoke(cliParser, cmd);
+        Assert.assertTrue("Expected valid for coverage-only mode", result);
+    }
+
+    @Test
+    public void testArgs_coverageOnlyMode_noTestResultsInSettings() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, ParseException {
+        CliParser cliParser = new CliParser();
+        Method inputFilesValidation = cliParser.getClass().getDeclaredMethod("addTestResultsFilesToSettings", CommandLine.class, Settings.class);
+        inputFilesValidation.setAccessible(true);
+        CommandLineParser parser = new DefaultParser();
+
+        // Coverage-only: no positional args -> inputXmlFileNames should remain null
+        CommandLine cmd = parser.parse(options, new String[]{
+                "--coverage-reports", "target/site/jacoco/*.xml",
+                "--coverage-report-type", "JACOCOXML",
+                "--build-context-server-id", "srv1",
+                "--build-context-job-id", "job1",
+                "--build-context-build-id", "build1"
+        });
+        Settings settings = new Settings();
+        Boolean result = (Boolean) inputFilesValidation.invoke(cliParser, cmd, settings);
+        Assert.assertTrue("Expected success for coverage-only mode (no test result files required)", result);
+        Assert.assertNull("inputXmlFileNames should be null in coverage-only mode", settings.getTestResultsFileNames());
     }
 }

--- a/test-result-collection-tool/src/test/java/com/microfocus/mqm/clt/FileGlobUtilsTest.java
+++ b/test-result-collection-tool/src/test/java/com/microfocus/mqm/clt/FileGlobUtilsTest.java
@@ -1,0 +1,229 @@
+/*
+ *     Copyright 2015-2023 Open Text
+ *
+ *     The only warranties for products and services of Open Text and
+ *     its affiliates and licensors ("Open Text") are as may be set forth
+ *     in the express warranty statements accompanying such products and services.
+ *     Nothing herein should be construed as constituting an additional warranty.
+ *     Open Text shall not be liable for technical or editorial errors or
+ *     omissions contained herein. The information contained herein is subject
+ *     to change without notice.
+ *
+ *     Except as specifically indicated otherwise, this document contains
+ *     confidential information and a valid license is required for possession,
+ *     use or copying. If this work is provided to the U.S. Government,
+ *     consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ *     Computer Software Documentation, and Technical Data for Commercial Items are
+ *     licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.microfocus.mqm.clt;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+public class FileGlobUtilsTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void literal_existingFile_absolutePath_returnsIt() throws IOException {
+        File f = tmp.newFile("report.xml");
+        List<String> result = FileGlobUtils.resolveGlobPattern(f.getAbsolutePath());
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals(f.getAbsolutePath(), result.get(0));
+    }
+
+    @Test
+    public void literal_nonExistentFile_returnsEmpty() {
+        List<String> result = FileGlobUtils.resolveGlobPattern("/this/path/does/not/exist/file.xml");
+        Assert.assertTrue("Expected empty list for non-existent literal path", result.isEmpty());
+    }
+
+    @Test
+    public void literal_directory_returnsEmpty() throws IOException {
+        File dir = tmp.newFolder("notAFile");
+        List<String> result = FileGlobUtils.resolveGlobPattern(dir.getAbsolutePath());
+        Assert.assertTrue("Expected empty list when path points to a directory", result.isEmpty());
+    }
+
+    @Test
+    public void singleLevel_matchesOnlyRequestedExtension() throws IOException {
+        File dir = tmp.newFolder("reports");
+        new File(dir, "a.xml").createNewFile();
+        new File(dir, "b.xml").createNewFile();
+        new File(dir, "c.txt").createNewFile();
+        new File(dir, "d.json").createNewFile();
+
+        String pattern = dir.getAbsolutePath() + File.separator + "*.xml";
+        List<String> result = FileGlobUtils.resolveGlobPattern(pattern);
+
+        Assert.assertEquals(2, result.size());
+        Assert.assertTrue(result.stream().anyMatch(p -> p.endsWith("a.xml")));
+        Assert.assertTrue(result.stream().anyMatch(p -> p.endsWith("b.xml")));
+        Assert.assertFalse(result.stream().anyMatch(p -> p.endsWith("c.txt")));
+    }
+
+    @Test
+    public void singleLevel_noMatch_returnsEmpty() throws IOException {
+        File dir = tmp.newFolder("emptyDir");
+        String pattern = dir.getAbsolutePath() + File.separator + "*.xml";
+        List<String> result = FileGlobUtils.resolveGlobPattern(pattern);
+        Assert.assertTrue("Expected empty list when no files match pattern", result.isEmpty());
+    }
+
+    @Test
+    public void singleLevel_nonExistentBaseDir_returnsEmpty() {
+        String pattern = tmp.getRoot().getAbsolutePath() + File.separator + "nonexistent" + File.separator + "*.xml";
+        List<String> result = FileGlobUtils.resolveGlobPattern(pattern);
+        Assert.assertTrue("Expected empty list when base directory does not exist", result.isEmpty());
+    }
+
+    @Test
+    public void singleLevel_doesNotDescendIntoSubdirectories() throws IOException {
+        File dir = tmp.newFolder("parent");
+        File sub = new File(dir, "child");
+        sub.mkdir();
+        new File(dir, "top.xml").createNewFile();
+        new File(sub, "nested.xml").createNewFile();
+
+        String pattern = dir.getAbsolutePath() + File.separator + "*.xml";
+        List<String> result = FileGlobUtils.resolveGlobPattern(pattern);
+
+        Assert.assertEquals(1, result.size());
+        Assert.assertTrue(result.get(0).endsWith("top.xml"));
+        Assert.assertFalse(result.stream().anyMatch(p -> p.endsWith("nested.xml")));
+    }
+
+    @Test
+    public void singleLevel_questionMarkWildcard() throws IOException {
+        File dir = tmp.newFolder("qmarks");
+        new File(dir, "t1.xml").createNewFile();
+        new File(dir, "t2.xml").createNewFile();
+        new File(dir, "t12.xml").createNewFile();
+
+        String pattern = dir.getAbsolutePath() + File.separator + "t?.xml";
+        List<String> result = FileGlobUtils.resolveGlobPattern(pattern);
+
+        Assert.assertEquals(2, result.size());
+        Assert.assertTrue(result.stream().anyMatch(p -> p.endsWith("t1.xml")));
+        Assert.assertTrue(result.stream().anyMatch(p -> p.endsWith("t2.xml")));
+        Assert.assertFalse(result.stream().anyMatch(p -> p.endsWith("t12.xml")));
+    }
+
+    @Test
+    public void singleLevel_starMatchesAllFiles() throws IOException {
+        File dir = tmp.newFolder("allFiles");
+        new File(dir, "foo.xml").createNewFile();
+        new File(dir, "bar.txt").createNewFile();
+        new File(dir, "baz.json").createNewFile();
+
+        String pattern = dir.getAbsolutePath() + File.separator + "*";
+        List<String> result = FileGlobUtils.resolveGlobPattern(pattern);
+
+        Assert.assertEquals(3, result.size());
+    }
+
+    @Test
+    public void singleLevel_resultsAreAbsolutePaths() throws IOException {
+        File dir = tmp.newFolder("absPaths");
+        new File(dir, "report.xml").createNewFile();
+
+        String pattern = dir.getAbsolutePath() + File.separator + "*.xml";
+        List<String> result = FileGlobUtils.resolveGlobPattern(pattern);
+
+        Assert.assertEquals(1, result.size());
+        Assert.assertTrue("Path should be absolute", new File(result.get(0)).isAbsolute());
+    }
+
+    @Test
+    public void recursive_matchesFilesAtAllDepths() throws IOException {
+        File root = tmp.newFolder("root");
+        File sub = new File(root, "sub");
+        File deep = new File(sub, "deep");
+        sub.mkdirs();
+        deep.mkdirs();
+
+        new File(root, "top.xml").createNewFile();
+        new File(sub, "mid.xml").createNewFile();
+        new File(deep, "bottom.xml").createNewFile();
+        new File(deep, "other.txt").createNewFile();
+
+        String pattern = root.getAbsolutePath() + File.separator + "**" + File.separator + "*.xml";
+        List<String> result = FileGlobUtils.resolveGlobPattern(pattern);
+
+        Assert.assertEquals(3, result.size());
+        Assert.assertTrue(result.stream().anyMatch(p -> p.endsWith("top.xml")));
+        Assert.assertTrue(result.stream().anyMatch(p -> p.endsWith("mid.xml")));
+        Assert.assertTrue(result.stream().anyMatch(p -> p.endsWith("bottom.xml")));
+        Assert.assertFalse(result.stream().anyMatch(p -> p.endsWith("other.txt")));
+    }
+
+    @Test
+    public void recursive_noMatch_returnsEmpty() throws IOException {
+        File root = tmp.newFolder("emptyTree");
+        new File(root, "sub").mkdirs();
+
+        String pattern = root.getAbsolutePath() + File.separator + "**" + File.separator + "*.xml";
+        List<String> result = FileGlobUtils.resolveGlobPattern(pattern);
+
+        Assert.assertTrue("Expected empty list when no files match in recursive walk", result.isEmpty());
+    }
+
+    @Test
+    public void recursive_onlyFilesReturned_notDirectories() throws IOException {
+        File root = tmp.newFolder("dirCheck");
+        new File(root, "sub").mkdirs();
+        new File(root, "file.xml").createNewFile();
+
+        String pattern = root.getAbsolutePath() + File.separator + "**" + File.separator + "*";
+        List<String> result = FileGlobUtils.resolveGlobPattern(pattern);
+
+        for (String path : result) {
+            Assert.assertTrue("Only regular files should be returned: " + path, new File(path).isFile());
+        }
+    }
+
+    @Test
+    public void forwardSlashSeparator_treatedSameAsSystemSeparator() throws IOException {
+        File dir = tmp.newFolder("slashTest");
+        new File(dir, "result.xml").createNewFile();
+
+        // Use forward slash even on Windows
+        String pattern = dir.getAbsolutePath().replace('\\', '/') + "/*.xml";
+        List<String> result = FileGlobUtils.resolveGlobPattern(pattern);
+
+        Assert.assertEquals(1, result.size());
+        Assert.assertTrue(result.get(0).endsWith("result.xml"));
+    }
+
+    @Test
+    public void singleLevel_matchesSampleJacocoFiles() {
+        String pattern = "src/test/resources/com/microfocus/mqm/clt/sample-*.xml";
+        List<String> result = FileGlobUtils.resolveGlobPattern(pattern);
+
+        Assert.assertEquals("Expected exactly 2 sample jacoco files", 2, result.size());
+        Assert.assertTrue(result.stream().anyMatch(p -> p.endsWith("sample-jacoco.xml")));
+        Assert.assertTrue(result.stream().anyMatch(p -> p.endsWith("sample-jacoco-2.xml")));
+    }
+}

--- a/test-result-collection-tool/src/test/resources/com/microfocus/mqm/clt/sample-jacoco-2.xml
+++ b/test-result-collection-tool/src/test/resources/com/microfocus/mqm/clt/sample-jacoco-2.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd">
+<report name="sample-project">
+    <package name="com/example/app">
+        <class name="com/example/app/StringUtils" sourcefilename="StringUtils.java">
+            <method name="&lt;init&gt;" desc="()V" line="3">
+                <counter type="INSTRUCTION" missed="0" covered="3"/>
+                <counter type="LINE" missed="0" covered="1"/>
+                <counter type="COMPLEXITY" missed="0" covered="1"/>
+                <counter type="METHOD" missed="0" covered="1"/>
+            </method>
+            <method name="isEmpty" desc="(Ljava/lang/String;)Z" line="6">
+                <counter type="INSTRUCTION" missed="0" covered="5"/>
+                <counter type="BRANCH" missed="0" covered="2"/>
+                <counter type="LINE" missed="0" covered="2"/>
+                <counter type="COMPLEXITY" missed="0" covered="2"/>
+                <counter type="METHOD" missed="0" covered="1"/>
+            </method>
+            <method name="reverse" desc="(Ljava/lang/String;)Ljava/lang/String;" line="11">
+                <counter type="INSTRUCTION" missed="0" covered="12"/>
+                <counter type="BRANCH" missed="0" covered="2"/>
+                <counter type="LINE" missed="0" covered="4"/>
+                <counter type="COMPLEXITY" missed="0" covered="2"/>
+                <counter type="METHOD" missed="0" covered="1"/>
+            </method>
+            <method name="capitalize" desc="(Ljava/lang/String;)Ljava/lang/String;" line="18">
+                <counter type="INSTRUCTION" missed="8" covered="0"/>
+                <counter type="BRANCH" missed="2" covered="0"/>
+                <counter type="LINE" missed="3" covered="0"/>
+                <counter type="COMPLEXITY" missed="2" covered="0"/>
+                <counter type="METHOD" missed="1" covered="0"/>
+            </method>
+            <counter type="INSTRUCTION" missed="8" covered="20"/>
+            <counter type="BRANCH" missed="2" covered="4"/>
+            <counter type="LINE" missed="3" covered="7"/>
+            <counter type="COMPLEXITY" missed="2" covered="5"/>
+            <counter type="METHOD" missed="1" covered="3"/>
+            <counter type="CLASS" missed="0" covered="1"/>
+        </class>
+        <sourcefile name="StringUtils.java">
+            <line nr="3" mi="0" ci="3" mb="0" cb="0"/>
+            <line nr="6" mi="0" ci="2" mb="0" cb="2"/>
+            <line nr="7" mi="0" ci="3" mb="0" cb="0"/>
+            <line nr="11" mi="0" ci="2" mb="0" cb="2"/>
+            <line nr="12" mi="0" ci="5" mb="0" cb="0"/>
+            <line nr="13" mi="0" ci="3" mb="0" cb="0"/>
+            <line nr="14" mi="0" ci="2" mb="0" cb="0"/>
+            <line nr="18" mi="0" ci="0" mb="2" cb="0"/>
+            <line nr="19" mi="5" ci="0" mb="0" cb="0"/>
+            <line nr="21" mi="3" ci="0" mb="0" cb="0"/>
+            <counter type="INSTRUCTION" missed="8" covered="20"/>
+            <counter type="BRANCH" missed="2" covered="4"/>
+            <counter type="LINE" missed="3" covered="7"/>
+            <counter type="COMPLEXITY" missed="2" covered="5"/>
+            <counter type="METHOD" missed="1" covered="3"/>
+            <counter type="CLASS" missed="0" covered="1"/>
+        </sourcefile>
+        <counter type="INSTRUCTION" missed="8" covered="20"/>
+        <counter type="BRANCH" missed="2" covered="4"/>
+        <counter type="LINE" missed="3" covered="7"/>
+        <counter type="COMPLEXITY" missed="2" covered="5"/>
+        <counter type="METHOD" missed="1" covered="3"/>
+        <counter type="CLASS" missed="0" covered="1"/>
+    </package>
+    <counter type="INSTRUCTION" missed="8" covered="20"/>
+    <counter type="BRANCH" missed="2" covered="4"/>
+    <counter type="LINE" missed="3" covered="7"/>
+    <counter type="COMPLEXITY" missed="2" covered="5"/>
+    <counter type="METHOD" missed="1" covered="3"/>
+    <counter type="CLASS" missed="0" covered="1"/>
+</report>
+

--- a/test-result-collection-tool/src/test/resources/com/microfocus/mqm/clt/sample-jacoco.xml
+++ b/test-result-collection-tool/src/test/resources/com/microfocus/mqm/clt/sample-jacoco.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+ *
+ *     Copyright 2015-2023 Open Text
+ *
+ *     The only warranties for products and services of Open Text and
+ *     its affiliates and licensors ("Open Text") are as may be set forth
+ *     in the express warranty statements accompanying such products and services.
+ *     Nothing herein should be construed as constituting an additional warranty.
+ *     Open Text shall not be liable for technical or editorial errors or
+ *     omissions contained herein. The information contained herein is subject
+ *     to change without notice.
+ *
+ *     Except as specifically indicated otherwise, this document contains
+ *     confidential information and a valid license is required for possession,
+ *     use or copying. If this work is provided to the U.S. Government,
+ *     consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ *     Computer Software Documentation, and Technical Data for Commercial Items are
+ *     licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+  -->
+<!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd">
+<report name="sample-project">
+    <package name="com/example/app">
+        <class name="com/example/app/Calculator" sourcefilename="Calculator.java">
+            <method name="&lt;init&gt;" desc="()V" line="3">
+                <counter type="INSTRUCTION" missed="0" covered="3"/>
+                <counter type="LINE" missed="0" covered="1"/>
+                <counter type="COMPLEXITY" missed="0" covered="1"/>
+                <counter type="METHOD" missed="0" covered="1"/>
+            </method>
+            <method name="add" desc="(II)I" line="7">
+                <counter type="INSTRUCTION" missed="0" covered="4"/>
+                <counter type="LINE" missed="0" covered="2"/>
+                <counter type="COMPLEXITY" missed="0" covered="1"/>
+                <counter type="METHOD" missed="0" covered="1"/>
+            </method>
+            <method name="divide" desc="(II)I" line="11">
+                <counter type="INSTRUCTION" missed="5" covered="6"/>
+                <counter type="BRANCH" missed="1" covered="1"/>
+                <counter type="LINE" missed="1" covered="3"/>
+                <counter type="COMPLEXITY" missed="1" covered="1"/>
+                <counter type="METHOD" missed="0" covered="1"/>
+            </method>
+            <counter type="INSTRUCTION" missed="5" covered="13"/>
+            <counter type="BRANCH" missed="1" covered="1"/>
+            <counter type="LINE" missed="1" covered="6"/>
+            <counter type="COMPLEXITY" missed="1" covered="3"/>
+            <counter type="METHOD" missed="0" covered="3"/>
+            <counter type="CLASS" missed="0" covered="1"/>
+        </class>
+        <sourcefile name="Calculator.java">
+            <line nr="3" mi="0" ci="3" mb="0" cb="0"/>
+            <line nr="7" mi="0" ci="3" mb="0" cb="0"/>
+            <line nr="8" mi="0" ci="1" mb="0" cb="0"/>
+            <line nr="11" mi="0" ci="3" mb="1" cb="1"/>
+            <line nr="12" mi="3" ci="0" mb="0" cb="0"/>
+            <line nr="14" mi="0" ci="2" mb="0" cb="0"/>
+            <line nr="15" mi="2" ci="0" mb="0" cb="0"/>
+            <counter type="INSTRUCTION" missed="5" covered="13"/>
+            <counter type="BRANCH" missed="1" covered="1"/>
+            <counter type="LINE" missed="1" covered="6"/>
+            <counter type="COMPLEXITY" missed="1" covered="3"/>
+            <counter type="METHOD" missed="0" covered="3"/>
+            <counter type="CLASS" missed="0" covered="1"/>
+        </sourcefile>
+        <counter type="INSTRUCTION" missed="5" covered="13"/>
+        <counter type="BRANCH" missed="1" covered="1"/>
+        <counter type="LINE" missed="1" covered="6"/>
+        <counter type="COMPLEXITY" missed="1" covered="3"/>
+        <counter type="METHOD" missed="0" covered="3"/>
+        <counter type="CLASS" missed="0" covered="1"/>
+    </package>
+    <counter type="INSTRUCTION" missed="5" covered="13"/>
+    <counter type="BRANCH" missed="1" covered="1"/>
+    <counter type="LINE" missed="1" covered="6"/>
+    <counter type="COMPLEXITY" missed="1" covered="3"/>
+    <counter type="METHOD" missed="0" covered="3"/>
+    <counter type="CLASS" missed="0" covered="1"/>
+</report>
+


### PR DESCRIPTION
# Related Backlog Item Link
User story [#3156086](https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=3156086)

# Description
- Up until now, the `octane-collection-tool` was only able to send test results. We want to extend it so it can also send code coverage reports file. 

# Proposed Solution
- We will keep the current functionality that expects plain arguments as inputs for the test results collection, while adding **2 optional parameters called** `--coverage-reports` which expects a pattern representing the path to one or multiple code coverage files and also `--coverage-report-type` which can have values currently supported by Octane code coverage pushing endpoint `JACOCOXML`, `SONAR_REPORT`, `LCOV`.  
- This is how users could call the octane-collection-tool with both functionalities:
    - `java -jar test-result-collection-tool\target\test-result-collection-tool.shade.jar --server "server" --shared-space 1001 --workspace 1002 --bearer-token "token" --build-context-server-id "build-context-server-id" --build-context-build-id "build-context-build-id" --build-context-job-id "build-context-job-id" --coverage-reports "test-result-collection-tool/src/test/resources/com/microfocus/mqm/clt/sample-jacoco.xml" --coverage-report-type "JACOCOXML" "C:\dev\octane-collection-tool\test-result-collection-tool\src\test\resources\com\microfocus\mqm\clt\multiple-test-results\TEST-*.xml"`

# Implementation description
- Since the parsing of the pattern coming from the `--coverage-reports` option, comes as a literal string, the bash doesn't handle the expansion of the glob pattern, like it does by default right now for the test results injection, so we had to implement a recursive way of extracting every file that matches the pattern from the path given(in case there are more) and send them to Octane one by one, since the `/coverage` endpoint only expects one file at a time. This logic is handled inside `FileGlobUtils`. Some unit tests have been added for this class as well, inside `FileGlobUtilsTest`
- Added two template coverage report files called `sample-jacoco.xml` and `sample-jacoco-2.xml` for actual tool testing purposes. They are also used in the `FileGlobUtilsTest` for some unit tests that check if the `resolveGlobPattern` method correctly identifies both files based on the pattern.
