### PR TITLE
defect#3181017 - Fix octane-collection-tool not injecting package name correctly for NUnit tests

### DIFF
--- a/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/xml/NunitXmlIterator.java
+++ b/test-result-collection-tool/src/main/java/com/microfocus/mqm/clt/xml/NunitXmlIterator.java
@@ -72,6 +72,7 @@ public class NunitXmlIterator extends AbstractXmlIterator<TestResult> {
     private static final String TEST_CASE_ELEMENT = "test-case";
     private static final String NAME_ELEMENT = "name";
     private static final String CLASSNAME_ELEMENT = "classname";
+    private static final String FULLNAME_ELEMENT = "fullname";
     private static final String RESULT_ELEMENT = "result";
     private static final String DURATION_ELEMENT = "duration";
     private static final String MESSAGE_ELEMENT = "message";
@@ -81,6 +82,7 @@ public class NunitXmlIterator extends AbstractXmlIterator<TestResult> {
 
     private String packageName;
     private String className;
+    private String fullName;
     private String testName;
     private TestResultStatus status;
     private long duration;
@@ -123,13 +125,16 @@ public class NunitXmlIterator extends AbstractXmlIterator<TestResult> {
                     if (NAME_ELEMENT.equals(attrName)) {
                         testName = restrictSizeTo255(attribute.getValue());
                     } else if (CLASSNAME_ELEMENT.equals(attrName)) {
-                        parseClassname(attribute.getValue());
+                        className = attribute.getValue();
+                    } else if (FULLNAME_ELEMENT.equals(attrName)) {
+                        fullName = attribute.getValue();
                     } else if (RESULT_ELEMENT.equals(attrName)) {
                         status = parseStatus(attribute.getValue());
                     } else if (DURATION_ELEMENT.equals(attrName)) {
                         duration = parseDuration(attribute.getValue());
                     }
                 }
+                parseNamespace(fullName, className, testName);
 
             } else if (MESSAGE_ELEMENT.equals(localName) && status == TestResultStatus.FAILED) {
                 insideFailureMessage = true;
@@ -180,21 +185,12 @@ public class NunitXmlIterator extends AbstractXmlIterator<TestResult> {
         }
     }
 
-    /** Splits a fully qualified NUnit classname into a package and a simple class name. */
-    private void parseClassname(String fullyQualifiedName) {
-        if (fullyQualifiedName == null || fullyQualifiedName.isEmpty()) {
-            packageName = EMPTY_STRING;
-            className = EMPTY_STRING;
-            return;
-        }
-        int lastDotIndex = fullyQualifiedName.lastIndexOf(PACKAGE_SEPARATOR);
-        if (lastDotIndex > 0) {
-            packageName = fullyQualifiedName.substring(0, lastDotIndex);
-            className = fullyQualifiedName.substring(lastDotIndex + 1);
-        } else {
-            packageName = EMPTY_STRING;
-            className = fullyQualifiedName;
-        }
+    private void parseNamespace(String fullName, String className, String testName) {
+        // fullname="CalculatorApp.Tests.CalculatorTests.FailedTest" methodname="FailedTest" classname="CalculatorTests"
+        String prefixTestName = PACKAGE_SEPARATOR + testName;
+        String prefixClassName = PACKAGE_SEPARATOR + className;
+        packageName = fullName.replace(prefixTestName, StringUtils.EMPTY)
+                .replace(prefixClassName, StringUtils.EMPTY);
     }
 
     /** Converts an NUnit duration (fractional seconds) to milliseconds. */

--- a/test-result-collection-tool/src/test/java/com/microfocus/mqm/clt/NunitXmlIteratorTest.java
+++ b/test-result-collection-tool/src/test/java/com/microfocus/mqm/clt/NunitXmlIteratorTest.java
@@ -105,6 +105,31 @@ public class NunitXmlIteratorTest {
                 TestResultStatus.PASSED, 5L);
     }
 
+    @Test
+    public void testNunit3_generatedFile() throws URISyntaxException, XMLStreamException, IOException, InterruptedException {
+        File xmlFile = new File(Objects.requireNonNull(getClass().getResource("NUnit3-generated-file.xml")).toURI());
+        List<TestResult> results = parseAll(xmlFile);
+
+        Assert.assertEquals(3, results.size());
+
+        TestResult failingTest = findByName(results, "FailingTest");
+        Assert.assertNotNull(failingTest);
+        assertTestResult(failingTest,
+                "TestApplication.Tests", "CalculatorTests", "FailingTest",
+                TestResultStatus.FAILED, 48L);
+        Assert.assertNull(failingTest.getErrorType());
+        Assert.assertEquals("Assert.That(calc.Add(2, 2), Is.EqualTo(5))\n                            Expected: 5\n                            But was:  4", failingTest.getErrorMsg().trim());
+        Assert.assertTrue(failingTest.getStackTraceStr().contains("CalculatorTests.cs:line 22"));
+
+        assertTestResult(Objects.requireNonNull(findByName(results, "PassingTest")),
+                "TestApplication.Tests", "CalculatorTests", "PassingTest",
+                TestResultStatus.PASSED, 0L);
+
+        assertTestResult(Objects.requireNonNull(findByName(results, "SkippedTest")),
+                "TestApplication.Tests", "CalculatorTests", "SkippedTest",
+                TestResultStatus.SKIPPED, 0L);
+    }
+
 
     @Test
     public void testNunit3_startedTimestamp() throws URISyntaxException, XMLStreamException, IOException, InterruptedException {

--- a/test-result-collection-tool/src/test/resources/com/microfocus/mqm/clt/NUnit3-allStatuses.xml
+++ b/test-result-collection-tool/src/test/resources/com/microfocus/mqm/clt/NUnit3-allStatuses.xml
@@ -32,12 +32,12 @@
 
         <test-case id="1-2" name="PassingTest"
                    fullname="com.example.tests.SampleFixture.PassingTest"
-                   classname="com.example.tests.SampleFixture"
+                   classname="SampleFixture"
                    result="Passed" duration="0.001"/>
 
         <test-case id="1-3" name="FailingTest"
                    fullname="com.example.tests.SampleFixture.FailingTest"
-                   classname="com.example.tests.SampleFixture"
+                   classname="SampleFixture"
                    result="Failed" duration="0.002">
             <failure>
                 <message><![CDATA[Expected 1 but was 2]]></message>
@@ -47,7 +47,7 @@
 
         <test-case id="1-4" name="SkippedTest"
                    fullname="com.example.tests.SampleFixture.SkippedTest"
-                   classname="com.example.tests.SampleFixture"
+                   classname="SampleFixture"
                    result="Skipped" duration="0.000">
             <reason>
                 <message><![CDATA[Ignored: not yet implemented]]></message>
@@ -56,12 +56,12 @@
 
         <test-case id="1-5" name="InconclusiveTest"
                    fullname="com.example.tests.SampleFixture.InconclusiveTest"
-                   classname="com.example.tests.SampleFixture"
+                   classname="SampleFixture"
                    result="Inconclusive" duration="0.003"/>
 
         <test-case id="1-6" name="AnotherPassingTest"
                    fullname="com.example.tests.SampleFixture.AnotherPassingTest"
-                   classname="com.example.tests.SampleFixture"
+                   classname="SampleFixture"
                    result="Passed" duration="0.004"/>
 
     </test-suite>

--- a/test-result-collection-tool/src/test/resources/com/microfocus/mqm/clt/NUnit3-generated-file.xml
+++ b/test-result-collection-tool/src/test/resources/com/microfocus/mqm/clt/NUnit3-generated-file.xml
@@ -1,0 +1,27 @@
+<test-suite type="Assembly" name="TestApplication.Tests.dll" fullname="/tmp/harness-_L40PzRnQmu-nUUI7eYvUg/harness-nunit/src/TestApplication.Tests/bin/Release/net8.0/TestApplication.Tests.dll" total="3" passed="1" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2026-06-15T11:48:23Z" end-time="2026-06-15T11:48:23Z" duration="0.0496959">
+    <test-suite type="TestSuite" name="TestApplication" fullname="TestApplication" total="3" passed="1" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2026-06-15T11:48:23Z" end-time="2026-06-15T11:48:23Z" duration="0.0496959">
+        <test-suite type="TestSuite" name="Tests" fullname="TestApplication.Tests" total="3" passed="1" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2026-06-15T11:48:23Z" end-time="2026-06-15T11:48:23Z" duration="0.0496959">
+            <test-suite type="TestFixture" name="CalculatorTests" fullname="TestApplication.Tests.CalculatorTests" classname="TestApplication.Tests.CalculatorTests" total="3" passed="1" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2026-06-15T11:48:23Z" end-time="2026-06-15T11:48:23Z" duration="0.0496959">
+                <test-case name="FailingTest" fullname="TestApplication.Tests.CalculatorTests.FailingTest" methodname="FailingTest" classname="CalculatorTests" result="Failed" start-time="2026-06-15T11:48:23Z" end-time="2026-06-15T11:48:23Z" duration="0.0489809" asserts="0" seed="1030203885">
+                    <failure>
+                        <message>  Assert.That(calc.Add(2, 2), Is.EqualTo(5))
+                            Expected: 5
+                            But was:  4
+                        </message>
+                        <stack-trace>   at TestApplication.Tests.CalculatorTests.FailingTest() in /tmp/harness-_L40PzRnQmu-nUUI7eYvUg/harness-nunit/src/TestApplication.Tests/CalculatorTests.cs:line 22
+
+                            1)    at TestApplication.Tests.CalculatorTests.FailingTest() in /tmp/harness-_L40PzRnQmu-nUUI7eYvUg/harness-nunit/src/TestApplication.Tests/CalculatorTests.cs:line 22
+
+                        </stack-trace>
+                    </failure>
+                </test-case>
+                <test-case name="PassingTest" fullname="TestApplication.Tests.CalculatorTests.PassingTest" methodname="PassingTest" classname="CalculatorTests" result="Passed" start-time="2026-06-15T11:48:23Z" end-time="2026-06-15T11:48:23Z" duration="0.000368" asserts="0" seed="286253631" />
+                <test-case name="SkippedTest" fullname="TestApplication.Tests.CalculatorTests.SkippedTest" methodname="SkippedTest" classname="CalculatorTests" result="Skipped" start-time="2026-06-15T11:48:23Z" end-time="2026-06-15T11:48:23Z" duration="0.000347" asserts="0" seed="1856145066">
+                    <output><![CDATA[Intentional skip
+]]></output>
+                </test-case>
+            </test-suite>
+        </test-suite>
+    </test-suite>
+    <errors />
+</test-suite>

--- a/test-result-collection-tool/src/test/resources/com/microfocus/mqm/clt/NUnit3-nestedSuites.xml
+++ b/test-result-collection-tool/src/test/resources/com/microfocus/mqm/clt/NUnit3-nestedSuites.xml
@@ -16,12 +16,12 @@
 
                     <test-case id="2-5" name="FirstTest"
                                fullname="com.example.DeepFixture.FirstTest"
-                               classname="com.example.DeepFixture"
+                               classname="DeepFixture"
                                result="Passed" duration="0.005"/>
 
                     <test-case id="2-6" name="SecondTest"
                                fullname="com.example.DeepFixture.SecondTest"
-                               classname="com.example.DeepFixture"
+                               classname="DeepFixture"
                                result="Passed" duration="0.005"/>
 
                 </test-suite>


### PR DESCRIPTION
## Related Backlog Item Link

Defect [#3181017](https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=3181017)

## Description

The octane collection tool was incorrectly injecting the package name into Octane which led to tests not being able to be triggered by a test runner.

## Proposed Solution

- Correctly parse the package name based on class name,test name and full name variables.
